### PR TITLE
Support asdf and tally version with GitHub CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Set up Elixir
       uses: actions/setup-elixir@v1
       with:
-        elixir-version: '1.10.3' # Define the elixir version [required]
-        otp-version: '22.3' # Define the OTP version [required]
+        elixir-version: '1.9.x'
+        otp-version: '22.x'
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 22.3
+elixir 1.9.4-otp-22


### PR DESCRIPTION
This PR supports asdf, tally up the Elixir and Erlang/OTP in GitHub CI, and set the min Elixir required version to 1.9.